### PR TITLE
реализация адаптивной верстки для content-page

### DIFF
--- a/components/centralContent/central-content.css
+++ b/components/centralContent/central-content.css
@@ -17,3 +17,14 @@
 .central-content__preview{
   grid-column: aside / end;
 }
+
+@media screen and (max-width: 480px){
+  .central-content__inner{
+    display: flex;
+    flex-flow: column;
+  }
+
+  .central-content__aside{
+    display: none;
+  }
+}

--- a/pages/template.html
+++ b/pages/template.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="ru" dir="ltr">
   <head>
+    <link rel="stylesheet" href="../assets/css/normolize.css">
     <link rel="stylesheet" href="../assets/css/main.css">
     <link rel="stylesheet" href="../components/container/container.css">
     <link rel="stylesheet" href="../components/page/page.css">
@@ -16,15 +17,13 @@
   </head>
 
 
-  <body style="margin: 0;">
+  <body>
     <div class="page">
       <div class="container">
      <header class="header">
          <div class="header__top-bar">
-        <!-- я добавлю спрайт -->   <svg class="header__logo" width="110" height="32" viewBox="0 0 110 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-           <rect y="1" width="30" height="30" fill="currentColor"/>
-           <rect x="38" width="32" height="32" rx="16" fill="currentColor"/>
-           <path d="M78 0L110 32H78V0Z" fill="currentColor"/>
+        <svg class="header__logo" width="110" height="32" viewBox="0 0 110 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <use href="../assets/icons.svg#logo"></use>
          </svg>
          <div class="header__toogles">
 


### PR DESCRIPTION
 в широкой версии центральная часть через грид делается.
в данном случае адаптивная верстка ограничелась удалением блока aside.
header не правлю, так как его правил в майн пейдж. жду апру того и другого и добавляю табы.